### PR TITLE
Missing dependency for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ publish: clean tag
         fi
 
 tag:
-        @if [ $$(git rev-list $$(git describe --abbrev=0 --tags)..HEAD --count) -gt 0 ]; then \
+	@if [ $$(git rev-list $$(git describe --abbrev=0 --tags)..HEAD --count) -gt 0 ]; then \
                 if [ $$(git log  -n 1 --oneline $$(git describe --abbrev=0 --tags)..HEAD CHANGELOG.md | wc -l) -gt 0 ]; then \
                         git tag $$(python setup.py --version) && git push --tags || echo 'Version already released, update your version!'; \
                 else \

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'console_scripts': ['envy = envy.application:main']
     },
     setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'mock'],
     test_suite="tests",
     install_requires=required,
     classifiers=[


### PR DESCRIPTION
When running tests, it complains about mock missing. So I added it to setup.py.

Beside, I specified the version as I think it's a good practice, you should specify them for the other dependencies to.
