### PR TITLE
add `envy clean --all` feature

### DIFF
--- a/envy/application.py
+++ b/envy/application.py
@@ -16,10 +16,6 @@ def get_envy_base():
     return os.path.expanduser("~/.envies")
 
 
-def get_envy_env_root():
-    return os.path.expanduser("~/.envies/{}".format(get_active_venv()))
-
-
 def get_active_venv():
     if 'VIRTUAL_ENV' in os.environ:
         return os.environ['VIRTUAL_ENV'].split('/')[-1]
@@ -111,7 +107,7 @@ def sync(args):
 @validate_env
 def clean(args):
     if args.all:
-        for package in os.listdir(get_envy_env_root()):
+        for package in os.listdir(get_envy_base() + "/{}".format(get_active_venv())):
             restore_environment(package)
     else:
         restore_environment(args.package[0])
@@ -181,7 +177,6 @@ def prepare_parser():
 def main():
     parser = prepare_parser()
     args = parser.parse_args()
-
     if hasattr(args, 'func'):
         args.func(args)
     else:

--- a/tests/envy_acceptance_test.py
+++ b/tests/envy_acceptance_test.py
@@ -30,11 +30,10 @@ def setup_test(f):
             with patch('envy.application.get_active_venv', return_value="someenv"):
                 with patch('envy.decorators.in_python_package', return_value=True):
                     with patch('envy.application.get_envy_base', return_value="{}/tests/testsrc/someuser/.envies/".format(base)):
-                        with patch('envy.application.get_envy_env_root', return_value="{}/tests/testsrc/someuser/.envies/someenv/".format(base)):
-                            with patch('envy.application.get_envy_path', return_value="{}/tests/testsrc/someuser/.envies/someenv/some_package".format(base)):
-                                with patch('envy.application.get_venv_full_package_path', return_value='{}/tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package'.format(base)):
-                                    with patch('os.path.expanduser', return_value="{}/tests/testsrc/someuser/src/some_package/some_package".format(base)):
-                                        return f(*args, **kwargs)
+                        with patch('envy.application.get_envy_path', return_value="{}/tests/testsrc/someuser/.envies/someenv/some_package".format(base)):
+                            with patch('envy.application.get_venv_full_package_path', return_value='{}/tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package'.format(base)):
+                                with patch('os.path.expanduser', return_value="{}/tests/testsrc/someuser/src/some_package/some_package".format(base)):
+                                    return f(*args, **kwargs)
 
     return wrap_patches
 

--- a/tests/envy_acceptance_test.py
+++ b/tests/envy_acceptance_test.py
@@ -30,10 +30,11 @@ def setup_test(f):
             with patch('envy.application.get_active_venv', return_value="someenv"):
                 with patch('envy.decorators.in_python_package', return_value=True):
                     with patch('envy.application.get_envy_base', return_value="{}/tests/testsrc/someuser/.envies/".format(base)):
-                        with patch('envy.application.get_envy_path', return_value="{}/tests/testsrc/someuser/.envies/someenv/some_package".format(base)):
-                            with patch('envy.application.get_venv_full_package_path', return_value='{}/tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package'.format(base)):
-                                with patch('os.path.expanduser', return_value="{}/tests/testsrc/someuser/src/some_package/some_package".format(base)):
-                                    return f(*args, **kwargs)
+                        with patch('envy.application.get_envy_env_root', return_value="{}/tests/testsrc/someuser/.envies/someenv/".format(base)):
+                            with patch('envy.application.get_envy_path', return_value="{}/tests/testsrc/someuser/.envies/someenv/some_package".format(base)):
+                                with patch('envy.application.get_venv_full_package_path', return_value='{}/tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package'.format(base)):
+                                    with patch('os.path.expanduser', return_value="{}/tests/testsrc/someuser/src/some_package/some_package".format(base)):
+                                        return f(*args, **kwargs)
 
     return wrap_patches
 
@@ -48,6 +49,8 @@ def test_sync_package_and_clean(mock_os):
 
     assert os.path.isdir('./tests/testsrc/someuser/.envies/someenv/some_package') == True
     assert os.path.isfile('./tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package/test.py') == True
+
+    args.all = False
 
     clean(args)
 
@@ -66,6 +69,7 @@ def test_sync_file_and_clean(mock_os):
     assert os.path.isdir('./tests/testsrc/someuser/.envies/someenv/some_package') == True
     assert os.path.isfile('./tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package/test.py') == True
 
+    args.all = True
     clean(args)
 
     assert os.path.isdir('./tests/testsrc/someuser/.envies/someenv/some_package') == False
@@ -84,7 +88,9 @@ def test_sync_file_from_inner_dir_and_clean(mock_os):
     assert os.path.isdir('./tests/testsrc/someuser/.envies/someenv/some_package') == True
     assert os.path.isfile('./tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package/test.py') == True
 
+    args.all = False
     clean(args)
+
 
     assert os.path.isdir('./tests/testsrc/someuser/.envies/someenv/some_package') == False
     assert os.path.isfile('./tests/testsrc/someuser/.virtualenvs/someenv/lib/python2.7/site-packages/some_package/test.py') == False


### PR DESCRIPTION
This allows users to restore all of the packages they have made changes to in their currently active virtualenv back to their original states with one command.

The following example illustrates this new functionality: 

`(foo) $ envy edit package1/bar.py`
`(foo) $ envy edit package2/blah.py`

After these two commands, the contents of `~/.envies/foo/` will contain a backup for both `package1` and `package2`.  

Currently, in order to restore both `package1` and `package2` to their original states,  one would have to run two `envy clean` commands:

  `(foo)$ envy clean package1`
  `(foo)$ envy clean package2`

This PR introduces a shortcut to accomplish this.  To restore **all** changed packages back to their unadulterated states, simply run:

`(foo) $ envy clean --all`

I feel that this is a useful feature, and am satisfied that it is production ready.  However, I've had some issues adding test support for this feature-- mostly because of the heavy patching used in the tests.
