### PR TITLE
add envy diff feature

### DIFF
--- a/envy/application.py
+++ b/envy/application.py
@@ -84,6 +84,18 @@ def edit(args):
     editor = get_editor()
     subprocess.call([editor, os.path.join(full_package_path, file_path)], shell = (editor == 'vim'))
 
+@validate_env
+def diff(args):
+    pkg_name_given_in_arg = args.path[0].split('/')[0]
+    full_package_path = get_venv_full_package_path(pkg_name_given_in_arg)
+    file_path = get_file_path(args.path[0])
+
+    if not original_backed_up(args.path[0]):
+        print ("no backup copy exists to diff with for  {}`".format(pkg_name_given_in_arg))
+        return
+
+    subprocess.call(['diff', os.path.join(full_package_path, file_path), os.path.join(get_envy_path(args.path[0]), file_path)])
+
 
 @validate_env
 @validate_pkg
@@ -172,6 +184,10 @@ def prepare_parser():
     parser_sync = subparsers.add_parser('sync', help='sync all files to active virtualenv')
     parser_sync.set_defaults(func=sync)
     parser_sync.add_argument('package', nargs=1, help='the name of changes to sync-- can either be package_name or a path to a file including the package name (i.e. foo/bar.py , where foo is the package)')
+
+    parser_diff = subparsers.add_parser('diff', help='edit dependency sourcefile')
+    parser_diff.set_defaults(func=diff)
+    parser_diff.add_argument('path', nargs=1)
 
     return parser
 

--- a/envy/application.py
+++ b/envy/application.py
@@ -84,18 +84,6 @@ def edit(args):
     editor = get_editor()
     subprocess.call([editor, os.path.join(full_package_path, file_path)], shell = (editor == 'vim'))
 
-@validate_env
-def diff(args):
-    pkg_name_given_in_arg = args.path[0].split('/')[0]
-    full_package_path = get_venv_full_package_path(pkg_name_given_in_arg)
-    file_path = get_file_path(args.path[0])
-
-    if not original_backed_up(args.path[0]):
-        print ("no backup copy exists to diff with for  {}`".format(pkg_name_given_in_arg))
-        return
-
-    subprocess.call(['diff', os.path.join(full_package_path, file_path), os.path.join(get_envy_path(args.path[0]), file_path)])
-
 
 @validate_env
 @validate_pkg
@@ -127,6 +115,19 @@ def clean(args):
         restore_environment(args.package)
 
 
+@validate_env
+def diff(args):
+    pkg_name_given_in_arg = args.path[0].split('/')[0]
+    full_package_path = get_venv_full_package_path(pkg_name_given_in_arg)
+    file_path = get_file_path(args.path[0])
+
+    if not original_backed_up(args.path[0]):
+        print ("no backup copy exists to diff with for  {}`".format(pkg_name_given_in_arg))
+        return
+
+    subprocess.call(['diff', os.path.join(full_package_path, file_path), os.path.join(get_envy_path(args.path[0]), file_path)])
+
+
 def restore_environment(package_name):
     if not os.path.isdir(get_envy_path(package_name)):
         print ("uh oh..no recorded backup in {}".format(get_envy_path(package_name)))
@@ -142,7 +143,6 @@ def restore_environment(package_name):
         # ensure successful copy before removing the backup.
         print ("removing .envie")
         shutil.rmtree(get_envy_path(package_name))
-
 
 
 def copytree(src, dst):
@@ -185,7 +185,7 @@ def prepare_parser():
     parser_sync.set_defaults(func=sync)
     parser_sync.add_argument('package', nargs=1, help='the name of changes to sync-- can either be package_name or a path to a file including the package name (i.e. foo/bar.py , where foo is the package)')
 
-    parser_diff = subparsers.add_parser('diff', help='edit dependency sourcefile')
+    parser_diff = subparsers.add_parser('diff', help='get diff of current state of site-package against backed up copies')
     parser_diff.set_defaults(func=diff)
     parser_diff.add_argument('path', nargs=1)
 


### PR DESCRIPTION
This PR allows for running diffs between the code sitting in the virtualenv and the associated backed up copies

This is crude in its current state- and I've only tested it so far on files (ie `envy diff foo/bar.py` -- and not `envy diff foo`). 

@hltbra do you have any suggestions here? Should I be using `subprocess` / is there a better utility I could be using for running the diff. 

CC @pguiv @andrewgross 
